### PR TITLE
added backbone frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@
 ######Front End Application Frameworks (backend agnostic)
 
 * [  ] [backbone](http://)
-	* [  ] [thorax](http://)
-	* [  ] [thorax](http://)
-	* [  ] [thorax](http://)
+	* [  ] [marionette](http://marionettejs.com)
+	* [  ] [chaplin](http://chaplinjs.github.com/)
+	* [  ] [aura](http://addyosmani.github.com/aura/)
+	* [  ] [thorax](http://walmartlabs.github.com/thorax/)
 * [  ] [ember](http://)
 * [  ] [knockout](http://)
 * [  ] [batman.js](http://)


### PR DESCRIPTION
I saw thorax was listed a few times as placeholders under Backbone, so I updated the list with the 4 most popular backbone frameworks (based on Github stars)
