### PR TITLE
almond should not be listed as a script loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@
 ######Auto Documentation
 
 * [  ] [yuiDoc](http://)
+* [  ] [docco](http://jashkenas.github.com/docco/)
+	* [  ] [docco-husky](https://github.com/mbrevoort/docco-husky)
+* [  ] [jsduck](https://github.com/senchalabs/jsduck)
+* [  ] [jsdoc](http://code.google.com/p/jsdoc-toolkit/)
+
+######CSS Auto Documentation
+
+* [  ] [kss](https://github.com/kneath/kss)
+* [  ] [styledocco/](http://jacobrask.github.com/styledocco/)
 
 ######JS Quality Validator
 


### PR DESCRIPTION
Taken from almonds description:
"A replacement AMD loader for RequireJS. It is a smaller "shim" loader, providing the minimal AMD API footprint that includes loader plugin support."

So I think it should be listed as a sibling to require.js, not as a script loader on its own
