### PR TITLE
Changed ender link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An opinionated list of tools for frontend (i.e. html, js, css) desktop/laptop (i
 
 * [bower](http://twitter.github.com/bower/)
 * [component](https://github.com/component/component)
-* [ender](http://ender.no.de/)
+* [ender](https://github.com/ender-js/Ender)
 * [jam](http://jamjs.org/)
 
 ---


### PR DESCRIPTION
I changed the link to Ember (browser package manager). 

Old link: http://ender.no.de | gives a 404 last days
New Link: https://github.com/ender-js/Ender | straight to github

Browser Package Managers
