### PR TITLE
Moved volo from script loader to build tools and browser package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ An opinionated list of tools for frontend (i.e. html, js, css) desktop/laptop (i
 * [anvil.js](https://github.com/anviljs/anvil.js/)
 * [modjs](http://modulejs.github.io/modjs/)
 * [AUTOMATON](http://indigounited.com/automaton/)
+* [volo](http://volojs.org/)
 
 ---
 
@@ -31,6 +32,7 @@ An opinionated list of tools for frontend (i.e. html, js, css) desktop/laptop (i
 * [component](https://github.com/component/component)
 * [ender](http://ender.jit.su/)
 * [jam](http://jamjs.org/)
+* [volo](http://volojs.org/)
 
 ---
 
@@ -142,7 +144,6 @@ An opinionated list of tools for frontend (i.e. html, js, css) desktop/laptop (i
 * [UMD (Universal Module Definition)](https://github.com/umdjs/umd)
 	* [UMD-inspired Module Boilerplate](https://gist.github.com/3880415)
 * [Inject](https://github.com/linkedin/inject)
-* [volo](http://volojs.org/)
 * [controlJS](http://controljs.org/)
 * [JAL](https://github.com/tail-f-systems/JAL)
 * [yepnope](http://yepnopejs.com/)


### PR DESCRIPTION
From volo's github README:

> At its heart, volo is a generic command runner

and from what I got when I was [introduced to it by jrburke's blog](http://tagneto.blogspot.ca/2012/07/on-client-components-for-web-apps.html), there's a big emphasis on how it does browser package management

I'm also curious where volo has a script loader.

[[Commit that moved volo out of build tools]](https://github.com/codylindley/frontend-tools/commit/7896fdb355c119d1a5d1e7f93ae241f041fe2914)
